### PR TITLE
Featurune unsubscribe

### DIFF
--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -26,6 +26,7 @@ class Public::CustomersController < ApplicationController
     @customer = current_customer
     @customer.update(is_active: false)
     reset_session
+    flash[:notice] = "退会処理を実行いたしました"
     redirect_to root_path
   end
 

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -19,6 +19,16 @@ class Public::CustomersController < ApplicationController
     end
   end
 
+  def unsubscribe
+  end
+
+  def withdraw
+    @customer = current_customer
+    @customer.update(is_active: false)
+    reset_session
+    redirect_to root_path
+  end
+
   private
 
   def customer_params

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -37,11 +37,14 @@ class Public::SessionsController < Devise::SessionsController
   private
 
   def customer_state
-    customer = Customer.find_by(:email params[:custome][:email])
+    customer = Customer.find_by(email: params[:customer][:email])
     return if customer.nil?
     return unless customer.valid_password?(params[:customer][:password])
-    if cusotmer.is_active == false
+    return if customer.is_active == true
+    if customer.is_active == false
+      flash[:notice] = "退会済みです。再度ご登録をしてご利用ください"
       redirect_to new_customer_registration_path
+    end
   end
 
 end

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Public::SessionsController < Devise::SessionsController
+  before_action :customer_state, only: [:create]
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in
@@ -31,6 +32,16 @@ class Public::SessionsController < Devise::SessionsController
 
   def after_sign_out_path_for(resource)
     root_path
+  end
+
+  private
+
+  def customer_state
+    customer = Customer.find_by(:email params[:custome][:email])
+    return if customer.nil?
+    return unless customer.valid_password?(params[:customer][:password])
+    if cusotmer.is_active == false
+      redirect_to new_customer_registration_path
   end
 
 end

--- a/app/views/public/customers/unsubscribe.html.erb
+++ b/app/views/public/customers/unsubscribe.html.erb
@@ -1,0 +1,12 @@
+<b class="d-flex justify-content-center align-items-center mb-3">本当に退会しますか？</b>
+
+  <p class="text-center">
+    退会すると会員登録情報や<br />
+    これまでの購入履歴が閲覧できなくなります<br />
+    退会する場合は、「退会する」をクリックしてください
+  </p>
+
+<div>
+  <%= link_to "退会しない", customers_my_page_path, class:"btn btn-primary" %>
+  <%= link_to "退会する", customers_withdraw_path, method: :patch, class:"btn btn-danger", "data-confirm" => "本当に退会しますか？" %>
+</div>

--- a/app/views/public/customers/unsubscribe.html.erb
+++ b/app/views/public/customers/unsubscribe.html.erb
@@ -1,12 +1,21 @@
-<b class="d-flex justify-content-center align-items-center mb-3">本当に退会しますか？</b>
+    <div class="mt-5 pt-5 mb-3">
+    <b class="d-flex justify-content-center align-items-center">本当に退会しますか？</b>
+    </div>
 
-  <p class="text-center">
-    退会すると会員登録情報や<br />
-    これまでの購入履歴が閲覧できなくなります<br />
-    退会する場合は、「退会する」をクリックしてください
-  </p>
-
-<div>
-  <%= link_to "退会しない", customers_my_page_path, class:"btn btn-primary" %>
-  <%= link_to "退会する", customers_withdraw_path, method: :patch, class:"btn btn-danger", "data-confirm" => "本当に退会しますか？" %>
+    <p class="text-center">
+      退会すると会員登録情報や<br />
+      これまでの購入履歴が閲覧できなくなります<br />
+      退会する場合は、「退会する」をクリックしてください
+    </p>
+    
+    <div class="container">
+      <div class="row d-flex justify-content-center">
+      <div class="col-2 mt-3">
+        <%= link_to "退会しない", customers_my_page_path, class:"btn btn-primary w-100" %>
+      </div>
+      <div class="col-2 mt-3">
+        <%= link_to "退会する", customers_withdraw_path, method: :patch, class:"btn btn-danger w-100", "data-confirm" => "本当に退会しますか？" %>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -1,3 +1,7 @@
+<div>
+  <%= flash[:notice] %>
+</div>
+
 <h4>新規会員登録</h4>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>


### PR DESCRIPTION
customersコントローラーにunsubscribeアクションを追加し、退会確認画面を作成しました。
customersコントローラーにwithdrawアクションを追加し、退会処理機能を作成しました。
publicのsessionsコントローラーに会員ステータスがアクティブでない顧客をログインさせない機能を作成しました。

bundle installとmigrateは必要ないです
